### PR TITLE
Fix for "Open images in tabs"-link only opening empty tabs in current Chrome build

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -12,6 +12,9 @@
 		"js": ["js/lib/jquery-1.8.1.min.js", "js/lib/jquery.hotkeys.js", "js/src/base.js", "js/src/hotkeys.js", "js/src/open_in_tabs.js", "js/src/story_in_gdocs.js", "js/src/highlighter.js"],
 		"run_at": "document_start"
 	}],
+	"web_accessible_resources": [
+		"tabdelay.html"
+	],
 	"homepage_url": "http://andrewneo.github.com/faextender-chrome/",
 	"options_page": "options.html",
 	"permissions": [


### PR DESCRIPTION
Changed manifest according to https://code.google.com/p/chromium/issues/detail?id=310870#c4 to fix the "Open images in tabs"-link only opening emtpy tabs in current Chrome build (33.0.1750.117 m)
