### PR TITLE
Refactor jQuery document ready function. Fixes User Settings

### DIFF
--- a/app/options.ts
+++ b/app/options.ts
@@ -99,7 +99,7 @@ function removeHighlight(e: JQuery.ClickEvent<HTMLInputElement>) {
     return saveHighlight();
 }
 
-jQuery(document).on("ready", () => {
+jQuery(function() {
     (async function() {
         await loadOptions();
         bindOptions();

--- a/app/tabdelay.ts
+++ b/app/tabdelay.ts
@@ -42,6 +42,6 @@ function tabDelayCountdown() {
     }
 }
 
-jQuery(document).on("ready", () => {
+jQuery(function() {
     tabDelayOnLoad();
 });


### PR DESCRIPTION
  - Fixed outdated jQuery syntax that was causing tab delay and settings page to not work
  - Replaced deprecated jQuery(document).on("ready", ...) with standard jQuery(function() {...}) pattern
  - This syntax was removed in jQuery 3.0, causing silent failures in both features

fixes #55 
  
Validated on Chrome and Firefox latest versions